### PR TITLE
Data GPU issue

### DIFF
--- a/genedisco/models/meta_models.py
+++ b/genedisco/models/meta_models.py
@@ -27,6 +27,11 @@ from slingpy.data_access.data_sources.abstract_data_source import AbstractDataSo
 from genedisco.models.abstract_embedding_retrieval_model import EmbeddingRetrievalModel
 
 
+def to_device(xs):
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    return [x.to(device) for x in xs]
+
+
 class SklearnRandomForestRegressor(AbstractMetaModel, SklearnModel):
     """The random forest regressor model from sklean (non-deep models)"""
     def __init__(self,
@@ -38,7 +43,7 @@ class SklearnRandomForestRegressor(AbstractMetaModel, SklearnModel):
         output uncertainty along with the average prediction.
 
         Args:
-            base_module: The base forest ensemble module. It can be from 
+            base_module: The base forest ensemble module. It can be from
             {RandomForestRegressor, ExtraTreesRegressor}
         """
 
@@ -58,7 +63,7 @@ class SklearnRandomForestRegressor(AbstractMetaModel, SklearnModel):
         file_path = os.path.join(save_folder_path, "model.pickle")
         model = PickleableBaseModel.load(file_path)
         return model
-    
+
     def get_samples(self, x: np.ndarray, k: Optional[int] = 1):
         k = self.n_estimators or k
         if k > self.n_estimators:
@@ -66,7 +71,7 @@ class SklearnRandomForestRegressor(AbstractMetaModel, SklearnModel):
                              " the number of estimators in ensemble models.")
         else:
             random_indices = np.random.randint(self.n_estimators, size=k)
-            y_samples = [self.model.estimators_[i].predict(x) 
+            y_samples = [self.model.estimators_[i].predict(x)
                          for i in random_indices]
             y_samples = np.swapaxes(y_samples, 0, 1)
         return y_samples
@@ -87,7 +92,7 @@ class SklearnRandomForestRegressor(AbstractMetaModel, SklearnModel):
             return y_pred
 
     def predict(self,
-                dataset_x: AbstractDataSource, 
+                dataset_x: AbstractDataSource,
                 batch_size: int = 256,
                 return_std_and_margin: bool = False) -> List[np.ndarray]:
         """
@@ -95,7 +100,7 @@ class SklearnRandomForestRegressor(AbstractMetaModel, SklearnModel):
             dataset_x: Input dataset to be evaluated.
             batch_size:
             return_std_and_margin: If True, return the epistemic uncertainty of the output.
-        
+
         Returns: If return_std_and_margin is True, returns ([output_means], [output_stds]).
                         Otherwise, returns [output_means]
         """
@@ -155,11 +160,16 @@ class PytorchMLPRegressorWithUncertainty(AbstractMetaModel, EmbeddingRetrievalMo
         self.num_target_samples = num_target_samples
         self.model = model
 
-    def fit(self, 
-            train_x: AbstractDataSource, 
+        if self.model:
+            self.model.preprocess_x_fn = to_device
+            self.model.preprocess_y_fn = to_device
+
+    def fit(self,
+            train_x: AbstractDataSource,
             train_y: Optional[AbstractDataSource] = None,
             validation_set_x: Optional[AbstractDataSource] = None,
             validation_set_y: Optional[AbstractDataSource] = None) -> AbstractBaseModel:
+
         return self.model.fit(train_x, train_y, validation_set_x, validation_set_y)
 
     def get_model_prediction(self,
@@ -176,9 +186,10 @@ class PytorchMLPRegressorWithUncertainty(AbstractMetaModel, EmbeddingRetrievalMo
             y_preds = self.get_samples(data, 1)
         return y_preds
 
-    def get_samples(self, 
-                    data: List[torch.Tensor], 
+    def get_samples(self,
+                    data: List[torch.Tensor],
                     k: Optional[int] = 1) -> List[torch.Tensor]:
+        data = to_device(data)
         y_samples = self.model.model(data, k)
         return y_samples
 
@@ -190,7 +201,7 @@ class PytorchMLPRegressorWithUncertainty(AbstractMetaModel, EmbeddingRetrievalMo
         """
         Args:
             return_std_and_margin: If True, return the epistemic uncertainty of the output.
-        
+
         Returns: If return_std is True, returns ([output_means], [output_stds]).
                         Otherwise, returns [output_means]
         """
@@ -210,9 +221,9 @@ class PytorchMLPRegressorWithUncertainty(AbstractMetaModel, EmbeddingRetrievalMo
             else:
                 y_pred = self.get_model_prediction(data, return_multiple_preds=False)
                 y_preds.append(y_pred)
-        
+
         y_preds = list(
-            map(lambda y_preds_i: torch.cat(y_preds_i, dim=0).detach().numpy(), 
+            map(lambda y_preds_i: torch.cat(y_preds_i, dim=0).cpu().detach().numpy(),
                 zip(*y_preds))
         )
         y_preds = np.squeeze(y_preds)


### PR DESCRIPTION
It seems like data are in cpu and model in GPU. Because of slingpy we can't easily move the data in GPU so I think the easier solution is to add preprocessors to the model to do this. Let me know if there's an easier way or a better fix from your side.

More details about the issue below:

How to repro: This fails
```
run_experiments \
  --cache_directory=/path/to/genedisco_cache  \
  --output_directory=/path/to/genedisco_output  \
  --acquisition_batch_size=64  \
  --num_active_learning_cycles=8  \
  --max_num_jobs=1
```
with the message
```
Traceback (most recent call last):
  File "/blah/bin/run_experiments", line 8, in <module>
    sys.exit(main())
  File "/blah/lib/python3.8/site-packages/genedisco/apps/run_experiments_application.py", line 139, in main
    results = app.run()
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/abstract_run_policy.py", line 62, in run
    run_results = self._run(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/abstract_base_application.py", line 419, in _run
    run_result = self.run_policy._run(**self.get_params())
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/local_single_run_policy.py", line 31, in _run
    return self.base_policy_fun(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/abstract_base_application.py", line 436, in run_single
    model = self.train_model()
  File "/blah/lib/python3.8/site-packages/genedisco/apps/run_experiments_application.py", line 128, in train_model
    outputs.append(RunExperimentsApplication.parallel_run_wrapper(arg, self_reference=self))
  File "/blah/lib/python3.8/site-packages/genedisco/apps/run_experiments_application.py", line 95, in parallel_run_wrapper
    app.run()
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/abstract_run_policy.py", line 62, in run
    run_results = self._run(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/abstract_base_application.py", line 419, in _run
    run_result = self.run_policy._run(**self.get_params())
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/local_single_run_policy.py", line 31, in _run
    return self.base_policy_fun(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/abstract_base_application.py", line 436, in run_single
    model = self.train_model()
  File "/blah/lib/python3.8/site-packages/genedisco/apps/active_learning_loop.py", line 220, in train_model
    results = app.run().run_result
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/abstract_run_policy.py", line 62, in run
    run_results = self._run(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/abstract_base_application.py", line 419, in _run
    run_result = self.run_policy._run(**self.get_params())
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/composite_run_policy.py", line 90, in _run
    result_dicts = list(map(
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/abstract_run_policy.py", line 97, in run_with_file_output
    run_results_w_metadata = base_policy.run(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/composite_run_policy.py", line 76, in run
    run_results = self._run(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/composite_run_policy.py", line 90, in _run
    result_dicts = list(map(
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/abstract_run_policy.py", line 97, in run_with_file_output
    run_results_w_metadata = base_policy.run(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/composite_run_policy.py", line 76, in run
    run_results = self._run(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/composite_run_policy.py", line 90, in _run
    result_dicts = list(map(
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/abstract_run_policy.py", line 97, in run_with_file_output
    run_results_w_metadata = base_policy.run(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/abstract_run_policy.py", line 62, in run
    run_results = self._run(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/run_policies/local_single_run_policy.py", line 31, in _run
    return self.base_policy_fun(**kwargs)
  File "/blah/lib/python3.8/site-packages/slingpy/apps/abstract_base_application.py", line 436, in run_single
    model = self.train_model()
  File "/blah/lib/python3.8/site-packages/genedisco/apps/single_cycle_application.py", line 246, in train_model
    self.model.fit(self.datasets.training_set_x,
  File "/blah/lib/python3.8/site-packages/genedisco/models/meta_models.py", line 163, in fit
    return self.model.fit(train_x, train_y, validation_set_x, validation_set_y)
  File "/blah/lib/python3.8/site-packages/slingpy/models/torch_model.py", line 171, in fit
    y_pred_i, loss = get_output_and_loss(inputs, labels)
  File "/blah/lib/python3.8/site-packages/slingpy/models/torch_model.py", line 154, in get_output_and_loss
    y_pred_i = self.model(model_inputs)
  File "/blah/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/blah/lib/python3.8/site-packages/genedisco/active_learning_methods/batchbald_redux/consistent_mc_dropout.py", line 45, in forward
    mc_output_BK = self.mc_forward_impl(mc_input_BK)[0]
  File "/blah/lib/python3.8/site-packages/genedisco/models/pytorch_models.py", line 54, in mc_forward_impl
    emb = self.fc1(x)
  File "/blah/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/blah/lib/python3.8/site-packages/torch/nn/modules/linear.py", line 94, in forward
    return F.linear(input, self.weight, self.bias)
  File "/blah/lib/python3.8/site-packages/torch/nn/functional.py", line 1753, in linear
    return torch._C._nn.linear(input, weight, bias)
RuntimeError: Tensor for argument #2 'mat1' is on CPU, but expected it to be on GPU (while checking arguments for addmm)
```