### PR TITLE
fix gene name mapping issue in dataloader

### DIFF
--- a/genedisco/datasets/features/achilles.py
+++ b/genedisco/datasets/features/achilles.py
@@ -1,5 +1,5 @@
 """
-Copyright 2021 Patrick Schwab, Arash Mehrjou, GlaxoSmithKline plc; Andrew Jesson, University of Oxford; Ashkan Soleymani, MIT
+Copyright 2021 Patrick Schwab, Arash Mehrjou, Yusuf Roohani, GlaxoSmithKline plc; Andrew Jesson, University of Oxford; Ashkan Soleymani, MIT
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -63,8 +63,12 @@ class Achilles(object):
 
             name_converter = HGNCNames(save_directory)
             gene_names = name_converter.update_outdated_gene_names(gene_names)
-            gene_names, idx_start = np.unique(sorted(gene_names), return_index=True)
-            data = data[idx_start]
+
+            data_df = pd.DataFrame(data)
+            data_df.index = gene_names
+            data_df = data_df.groupby(data_df.index).mean()
+            gene_names, data = data_df.index.values.tolist(), data_df.values.astype(np.float32)
+
             HDF5Tools.save_h5_file(h5_file,
                                    data,
                                    "achilles",

--- a/genedisco/datasets/screens/schmidt_2021_t_cells_ifng.py
+++ b/genedisco/datasets/screens/schmidt_2021_t_cells_ifng.py
@@ -1,5 +1,5 @@
 """
-Copyright 2021 Patrick Schwab, Arash Mehrjou, GlaxoSmithKline plc; Andrew Jesson, University of Oxford; Ashkan Soleymani, MIT
+Copyright 2021 Patrick Schwab, Arash Mehrjou, Yusuf Roohani, GlaxoSmithKline plc; Andrew Jesson, University of Oxford; Ashkan Soleymani, MIT
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,12 +50,15 @@ class Schmidt2021TCellsIFNg(object):
             group_by_row_index = df.groupby(df.index)
             df = group_by_row_index.mean()
 
-            gene_names, data = df.index.values.tolist(), df[['pos|lfc']].values.astype(np.float32)
+            gene_names = df.index.values.tolist()
 
             name_converter = HGNCNames(save_directory)
             gene_names = name_converter.update_outdated_gene_names(gene_names)
-            gene_names, idx_start = np.unique(gene_names, return_index=True)
-            data = data[idx_start]
+            df.index = gene_names
+
+            # Merge duplicate indices by averaging
+            df = df.groupby(df.index).mean()
+            gene_names, data = df.index.values.tolist(), df[['pos|lfc']].values.astype(np.float32)
 
             HDF5Tools.save_h5_file(h5_file,
                                    data,

--- a/genedisco/datasets/screens/schmidt_2021_t_cells_il2.py
+++ b/genedisco/datasets/screens/schmidt_2021_t_cells_il2.py
@@ -1,5 +1,5 @@
 """
-Copyright 2021 Patrick Schwab, Arash Mehrjou, GlaxoSmithKline plc; Andrew Jesson, University of Oxford; Ashkan Soleymani, MIT
+Copyright 2021 Patrick Schwab, Arash Mehrjou, Yusuf Roohani, GlaxoSmithKline plc; Andrew Jesson, University of Oxford; Ashkan Soleymani, MIT
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,12 +50,15 @@ class Schmidt2021TCellsIL2(object):
             group_by_row_index = df.groupby(df.index)
             df = group_by_row_index.mean()
 
-            gene_names, data = df.index.values.tolist(), df[['pos|lfc']].values.astype(np.float32)
+            gene_names = df.index.values.tolist()
 
             name_converter = HGNCNames(save_directory)
             gene_names = name_converter.update_outdated_gene_names(gene_names)
-            gene_names, idx_start = np.unique(gene_names, return_index=True)
-            data = data[idx_start]
+            df.index = gene_names
+
+            # Merge duplicate indices by averaging
+            df = df.groupby(df.index).mean()
+            gene_names, data = df.index.values.tolist(), df[['pos|lfc']].values.astype(np.float32)
 
             HDF5Tools.save_h5_file(h5_file,
                                    data,


### PR DESCRIPTION
In the dataloader for the Schmidt IFNG and IL2 screen datasets as well as in the Achilles feature dataset, the call to `np.unique` was shuffling the order of the genes and their mapping to the correct phenotype/feature. I've made a few small changes in the code to correct for this. I tested the code by reproducing the results in the paper. This wasn't working with the previous version of the code.

![image](https://github.com/genedisco/genedisco/assets/12547304/6e23a6e3-806a-48fd-b334-db91f5c5935c)

The results in this figure was generated by running:
`python active_learning_loop.py --cache_directory="coreset_cache/" --output_directory="results_coreset/" --model_name="bayesian_mlp" --acquisition_function_name="coreset" --acquisition_batch_size=256 --num_active_learning_cycles=20 --feature_set_name="achilles" --dataset_name="schmidt_2021_ifng"`

It's likely the same issue exists with the other datasets but I haven't looked through that yet.