### PR TITLE
Update hgnc folder

### DIFF
--- a/genedisco/datasets/features/hgnc_names.py
+++ b/genedisco/datasets/features/hgnc_names.py
@@ -22,7 +22,7 @@ from slingpy.utils.logging import warn
 
 
 class HGNCNames(object):
-    FILE_URL = "http://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/locus_types/gene_with_protein_product.txt"
+    FILE_URL = "http://ftp.ebi.ac.uk/pub/databases/genenames/out_of_date_hgnc/tsv/locus_types/gene_with_protein_product.txt"
 
     def __init__(self, cache_directory: AnyStr):
         self.hgnc_mappings = {}


### PR DESCRIPTION
When I was trying to use the perturbation embeddings there was an error because the name of the folder is deprecated. I just changed it to the "out_of_date_hgnc" (assuming is the same data initially used) so that I can get the embeddings.